### PR TITLE
fix chosen plugin metadata

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
 		, "fontawesome": "4.3.0"
 		, "knockout": "3.3.0"
 		, "bootbox": "4.4.0"
-		, "chosen": "harvesthq/chosen#~1.4.2"		
+		, "chosen": "~1.4.2"
 	}
 }

--- a/src/main/webapp/WEB-INF/tags/page.tag
+++ b/src/main/webapp/WEB-INF/tags/page.tag
@@ -15,7 +15,7 @@
 	<link rel="stylesheet" type="text/css" href="<c:url value="/resources/bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" />">
 
 	<link rel="stylesheet" type="text/css" href="<c:url value="/resources/css/style.css" />">
-	<link rel="stylesheet" type="text/css" href="<c:url value="/resources/bower_components/chosen_v1.4.0/chosen.css" />">
+	<link rel="stylesheet" type="text/css" href="<c:url value="/resources/bower_components/chosen/chosen.min.css" />">
 
 	<script type="text/javascript" src="<c:url value="/resources/public/js/require-config.js" />"></script>
 	<script type="text/javascript" src="<c:url value="/resources/bower_components/requirejs/require.js" />"></script>

--- a/src/main/webapp/resources/public/js/require-config.js
+++ b/src/main/webapp/resources/public/js/require-config.js
@@ -14,7 +14,7 @@ var require = {
 		, text: "bower_components/text/text"
 		, bootstrap: "bower_components/bootstrap/dist/js/bootstrap.min"
 		, knockout: "bower_components/knockout/dist/knockout"
-		, chosen: "bower_components/chosen_v1.4.0/chosen.jquery"
+		, chosen: "bower_components/chosen/chosen.jquery.min"
 		, datetimepicker: "bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min"
 		, moment: "bower_components/moment/min/moment-with-locales.min"
 		, bootbox: "bower_components/bootbox/bootbox"


### PR DESCRIPTION
when building project afresh with updating all bower components it appears that paths to chosen.js and chosen.css are incorrect. Currently deployed system works because it has old version still downloaded.
