### PR TITLE
Set build encoding for java source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<org.slf4j-version>1.6.1</org.slf4j-version>
 		<jackson-version>2.4.4</jackson-version>
 		<postgres.driver.version>9.3-1100-jdbc41</postgres.driver.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 


### PR DESCRIPTION
This is necessary for building sources on server.
