### PR TITLE
Disable timeout for script loading

### DIFF
--- a/src/main/webapp/resources/public/js/require-config.js
+++ b/src/main/webapp/resources/public/js/require-config.js
@@ -54,7 +54,9 @@ var require = {
 			export: "$",
 			deps: [ 'jquery' ]
 		}
-	}
+	},
+
+	waitTimeout: 0
 
 	, deps: [ "jquery", "backbone", "underscore", "text", 'bootstrap', 'translator' ],
 


### PR DESCRIPTION
jqx-all script size is around 3M.
Default timeout of `require.js` is 7 sec. [see documentation](http://requirejs.org/docs/api.html#config-waitSeconds)

It doesn't always load in time when internet is slow or server is under load. `waitSeconds` property is set to 0 which disables timeout altogether.

![2015-10-20_totalizator_script-timeout-issue](https://cloud.githubusercontent.com/assets/1268169/10614001/99ae486a-7760-11e5-816a-8b72a98c4e72.png)
